### PR TITLE
Add Meeting Agent API Docs and Register `meeting_followup_agent` in Supervisor Registry

### DIFF
--- a/app/registry.py
+++ b/app/registry.py
@@ -36,13 +36,14 @@ def load_registry() -> List[AgentMetadata]:
             endpoint="https://example.com/summarizer/handle",
             healthcheck="https://example.com/summarizer/health",
         ),
-        AgentMetadata(
+       AgentMetadata(
             name="meeting_followup_agent",
-            description="Generates meeting follow-ups: action items, summaries, due dates.",
-            intents=["meeting.followup"],
+            description="ONLY for meeting transcripts: extracts action items (with assignees and deadlines), generates meeting summaries, identifies follow-up tasks. Use ONLY when query mentions meetings, transcripts, standups, action items, or follow-ups.",
+            intents=["meeting.followup", "meeting.process", "meeting.analyze", "action_items.extract"],
             type="http",
-            endpoint="https://example.com/meeting/handle",
-            healthcheck="https://example.com/meeting/health",
+            endpoint="https://meeting-minutes-backend-spm-production.up.railway.app/agents/supervisor/meeting-followup",
+            healthcheck="https://meeting-minutes-backend-spm-production.up.railway.app/agents/supervisor/health",
+            timeout_ms=30000,
         ),
         AgentMetadata(
             name="onboarding_buddy_agent",


### PR DESCRIPTION
## Summary
This PR adds concise API documentation for the Meeting Agent backend and registers the `meeting_followup_agent` in the supervisor agent registry with its production endpoints.

---

Introduced brief docs outlining the core backend REST endpoints:

- **POST /meetings** — upload audio or transcript  
- **GET /meetings/<id>** — retrieve processed meeting data  
- **POST /meetings/<id>/process** — run transcription + summarization + action-item pipelines  
- **GET /health** — health check endpoint  

## **Supervisor Registry Update**
Registered a new agent:

- **Name:** `meeting_followup_agent`  
- **Intents:** `meeting.followup`, `meeting.process`, `meeting.analyze`, `action_items.extract`  
- **Endpoint:** `https://meeting-minutes-backend-spm-production.up.railway.app/agents/supervisor/meeting-followup`  
- **Healthcheck:** `https://meeting-minutes-backend-spm-production.up.railway.app/agents/supervisor/health`  
- **Timeout:** `30000ms`  